### PR TITLE
new: Add styled components based API.

### DIFF
--- a/configs/eslint.js
+++ b/configs/eslint.js
@@ -13,6 +13,7 @@ module.exports = {
   rules: {
     'react/forbid-prop-types': 'off',
     'react/no-unused-prop-types': 'off',
+    'react/prop-types': 'off',
     'react/require-default-props': 'off',
 
     // Broken

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lerna": "^3.22.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "rollup": "^2.28.1",
+    "rollup": "^2.28.2",
     "rollup-plugin-node-externals": "^2.2.0",
     "rut-dom": "^1.0.2"
   },

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^16.13.0"
   },
   "devDependencies": {
-    "@aesthetic/addon-mixins": "^0.1.3",
+    "@aesthetic/addon-mixins": "^0.1.4",
     "prop-types": "^15.7.2"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@aesthetic/core": "^0.4.5",
+    "@aesthetic/core": "^0.4.6",
     "@aesthetic/types": "^0.2.1",
-    "@aesthetic/utils": "^0.4.2",
+    "@aesthetic/utils": "^0.4.3",
     "direction": "^1.0.4",
     "hoist-non-react-statics": "^3.3.2"
   },
@@ -30,7 +30,7 @@
     "react": "^16.6.0"
   },
   "devDependencies": {
-    "@aesthetic/addon-mixins": "^0.1.3",
+    "@aesthetic/addon-mixins": "^0.1.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@aesthetic/core": "^0.4.4",
+    "@aesthetic/core": "^0.4.5",
     "@aesthetic/types": "^0.2.1",
     "@aesthetic/utils": "^0.4.2",
     "direction": "^1.0.4",

--- a/packages/react/src/ThemeContext.ts
+++ b/packages/react/src/ThemeContext.ts
@@ -1,4 +1,13 @@
 import React from 'react';
+import { getActiveTheme, Theme } from '@aesthetic/core';
 import { ThemeContextType } from './types';
 
-export default React.createContext<ThemeContextType | null>(null);
+let theme: Theme | null = null;
+
+try {
+  theme = getActiveTheme();
+} catch {
+  // Ignore
+}
+
+export default React.createContext<ThemeContextType | null>(theme);

--- a/packages/react/src/ThemeContext.ts
+++ b/packages/react/src/ThemeContext.ts
@@ -1,13 +1,6 @@
 import React from 'react';
-import { getActiveTheme, Theme } from '@aesthetic/core';
+import { getActiveTheme } from '@aesthetic/core';
+import { attempt } from '@aesthetic/utils';
 import { ThemeContextType } from './types';
 
-let theme: Theme | null = null;
-
-try {
-  theme = getActiveTheme();
-} catch {
-  // Ignore
-}
-
-export default React.createContext<ThemeContextType | null>(theme);
+export default React.createContext<ThemeContextType | null>(attempt(() => getActiveTheme()));

--- a/packages/react/src/createStyled.ts
+++ b/packages/react/src/createStyled.ts
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { createComponentStyles, LocalBlock, Utilities } from '@aesthetic/core';
 import useStyles from './useStyles';
 
 export default function createStyled<T extends keyof JSX.IntrinsicElements>(
   type: T,
   factory: (utilities: Utilities<LocalBlock>) => LocalBlock,
-): React.ForwardRefExoticComponent<JSX.IntrinsicElements[T]> {
+) /* infer */ {
   if (__DEV__) {
     if (typeof factory !== 'function') {
       throw new TypeError(
@@ -20,7 +20,7 @@ export default function createStyled<T extends keyof JSX.IntrinsicElements>(
 
   const Component = React.forwardRef<unknown, JSX.IntrinsicElements[T]>((props, ref) => {
     const cx = useStyles(styleSheet);
-    let className = cx('element');
+    let className = useMemo(() => cx('element'), [cx]);
 
     if (props.className) {
       className += ` ${props.className}`;

--- a/packages/react/src/createStyled.ts
+++ b/packages/react/src/createStyled.ts
@@ -32,7 +32,7 @@ export default function createStyled<
     const typeOfType = typeof type;
     const typeOfFactory = typeof factory;
 
-    if (typeOfType !== 'string') {
+    if (typeOfType !== 'string' && typeOfType !== 'object') {
       throw new TypeError(
         `Styled components must extend an HTML element or React component, found ${typeOfType}.`,
       );

--- a/packages/react/src/createStyled.ts
+++ b/packages/react/src/createStyled.ts
@@ -12,7 +12,7 @@ import { ElementType, InferProps, StyledInheritedProps } from './types';
 function getVariantsFromProps<V extends object>(styleSheet: LocalSheet<{}>, props: object): V {
   const variants: Record<string, unknown> = {};
 
-  styleSheet.metadata.element?.variantTypes.forEach((name) => {
+  styleSheet.metadata.element?.variantTypes?.forEach((name) => {
     if (name in props) {
       variants[name] = (props as Record<string, unknown>)[name];
     }

--- a/packages/react/src/createStyled.ts
+++ b/packages/react/src/createStyled.ts
@@ -7,7 +7,7 @@ import {
   LocalSheet,
 } from '@aesthetic/core';
 import useStyles from './useStyles';
-import { ElementType, InferProps, StyledInheritedProps } from './types';
+import { ElementType, InferProps, StyledComponent } from './types';
 
 function getVariantsFromProps<V extends object>(styleSheet: LocalSheet<{}>, props: object): V {
   const variants: Record<string, unknown> = {};
@@ -21,21 +21,24 @@ function getVariantsFromProps<V extends object>(styleSheet: LocalSheet<{}>, prop
   return variants as V;
 }
 
+// eslint-disable-next-line complexity
 export default function createStyled<
   T extends ElementType | React.ComponentType,
   V extends object = {}
 >(
   type: T,
   factory: LocalBlock | ((utilities: Utilities<LocalBlock>) => LocalBlock),
-): React.ForwardRefExoticComponent<InferProps<T> & StyledInheritedProps & V> {
+): StyledComponent<InferProps<T> & V> {
   if (__DEV__) {
     const typeOfType = typeof type;
     const typeOfFactory = typeof factory;
 
-    if (typeOfType !== 'string' && typeOfType !== 'object') {
+    if (typeOfType !== 'string' && typeOfType !== 'function' && typeOfType !== 'object') {
       throw new TypeError(
         `Styled components must extend an HTML element or React component, found ${typeOfType}.`,
       );
+    } else if ((typeOfType === 'function' || typeOfType === 'object') && !('styleSheet' in type)) {
+      throw new TypeError(`Styled components may only extend other styled components.`);
     }
 
     if (typeOfFactory !== 'function' && typeOfFactory !== 'object') {
@@ -63,7 +66,7 @@ export default function createStyled<
 
     return React.createElement(type, {
       ...props,
-      // These dont type correctly because all of our inference
+      // These dont type correctly because of our inference
       // @ts-expect-error
       className,
       ref,
@@ -76,6 +79,8 @@ export default function createStyled<
       : String((type as React.ComponentType).displayName || (type as Function).name);
 
   Component.displayName = `styled(${displayName})`;
+
+  (Component as StyledComponent).styleSheet = styleSheet;
 
   // Use the return type of `createStyled` instead of `forwardRef`
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react/src/createStyled.ts
+++ b/packages/react/src/createStyled.ts
@@ -17,18 +17,20 @@ function getVariantsFromProps<V extends object>(styleSheet: LocalSheet<{}>, prop
 
 export default function createStyled<T extends ElementType, V extends object = {}>(
   type: T,
-  factory: (utilities: Utilities<LocalBlock>) => LocalBlock,
+  factory: LocalBlock | ((utilities: Utilities<LocalBlock>) => LocalBlock),
 ): React.ForwardRefExoticComponent<JSX.IntrinsicElements[T] & V> {
   if (__DEV__) {
-    if (typeof factory !== 'function') {
+    const typeOfFactory = typeof factory;
+
+    if (typeOfFactory !== 'function' && typeOfFactory !== 'object') {
       throw new TypeError(
-        `Styled components require a style sheet factory function, found ${typeof factory}.`,
+        `Styled components require a style sheet factory function, found ${typeOfFactory}.`,
       );
     }
   }
 
   const styleSheet = createComponentStyles((utils) => ({
-    element: factory(utils),
+    element: typeof factory === 'function' ? factory(utils) : factory,
   }));
 
   const Component = React.forwardRef<unknown, JSX.IntrinsicElements[T] & V>((props, ref) => {

--- a/packages/react/src/createStyled.ts
+++ b/packages/react/src/createStyled.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+import { createComponentStyles, LocalBlock, Utilities } from '@aesthetic/core';
+import useStyles from './useStyles';
+
+export default function createStyled<T extends keyof JSX.IntrinsicElements>(
+  type: T,
+  factory: (utilities: Utilities<LocalBlock>) => LocalBlock,
+): React.ForwardRefExoticComponent<JSX.IntrinsicElements[T]> {
+  if (__DEV__) {
+    if (typeof factory !== 'function') {
+      throw new TypeError(
+        `Styled components require a style sheet factory function, found ${typeof factory}.`,
+      );
+    }
+  }
+
+  const styleSheet = createComponentStyles((utils) => ({
+    element: factory(utils),
+  }));
+
+  const Component = React.forwardRef<unknown, JSX.IntrinsicElements[T]>((props, ref) => {
+    const cx = useStyles(styleSheet);
+    let className = cx('element');
+
+    if (props.className) {
+      className += ` ${props.className}`;
+    }
+
+    return React.createElement(type, {
+      ...props,
+      className,
+      ref,
+    });
+  });
+
+  Component.displayName = `styled(${type})`;
+
+  return Component;
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -8,6 +8,7 @@ import DirectionProvider from './DirectionProvider';
 import ThemeContext from './ThemeContext';
 import ThemeProvider from './ThemeProvider';
 import ContextualThemeProvider from './ContextualThemeProvider';
+import createStyled from './createStyled';
 import useDirection from './useDirection';
 import useStyles from './useStyles';
 import useTheme from './useTheme';
@@ -24,6 +25,7 @@ export {
   ThemeContext,
   ThemeProvider,
   ContextualThemeProvider,
+  createStyled,
   useDirection,
   useStyles,
   useTheme,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -14,6 +14,16 @@ export interface ClassNameGenerator<T> {
 
 export type ElementType = keyof JSX.IntrinsicElements;
 
+export interface StyledInheritedProps {
+  className?: string;
+}
+
+export type InferProps<T extends ElementType | React.ComponentType> = T extends ElementType
+  ? JSX.IntrinsicElements[T]
+  : T extends React.ComponentType<infer P>
+  ? P
+  : never;
+
 // CONTEXT
 
 export type DirectionContextType = Direction;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import React from 'react';
-import { Theme, ClassNameSheetVariants } from '@aesthetic/core';
+import { Theme, ClassNameSheetVariants, LocalSheet } from '@aesthetic/core';
 import { ClassName, Direction, ThemeName } from '@aesthetic/types';
 
 export type ClassNameTypes<T> = (undefined | null | false | T)[];
@@ -13,6 +13,11 @@ export interface ClassNameGenerator<T> {
 }
 
 export type ElementType = keyof JSX.IntrinsicElements;
+
+export interface StyledComponent<P extends object = {}>
+  extends React.ForwardRefExoticComponent<P & StyledInheritedProps> {
+  styleSheet: LocalSheet;
+}
 
 export interface StyledInheritedProps {
   className?: string;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -12,6 +12,8 @@ export interface ClassNameGenerator<T> {
   (...keys: ClassNameTypes<T>): ClassName;
 }
 
+export type ElementType = keyof JSX.IntrinsicElements;
+
 // CONTEXT
 
 export type DirectionContextType = Direction;

--- a/packages/react/tests/ThemeProvider.test.tsx
+++ b/packages/react/tests/ThemeProvider.test.tsx
@@ -21,9 +21,6 @@ jest.mock('@aesthetic/core');
 
 describe('ThemeProvider', () => {
   beforeEach(() => {
-    // @ts-expect-error Only need to mock matches
-    window.matchMedia = () => ({ matches: false });
-
     lightTheme.name = 'day';
     darkTheme.name = 'night';
 

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -1,12 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createStyled() can access the ref 1`] = `
+exports[`createStyled() can access the ref from multiple layers of composition 1`] = `
 "<Wrapper>
   <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
     <div dir=\\"ltr\\">
       <ThemeProvider name=\\"twilight\\">
         <ForwardRef>
-          <svg ref={mockConstructor()} className=\\"a b c\\" />
+          <ForwardRef className=\\"\\">
+            <ForwardRef className=\\"\\">
+              <ForwardRef className=\\"\\">
+                <main ref={mockConstructor()} className=\\"\\" />
+              </ForwardRef>
+            </ForwardRef>
+          </ForwardRef>
         </ForwardRef>
       </ThemeProvider>
     </div>
@@ -89,6 +95,40 @@ exports[`createStyled() only renders styles once, even when component rerenders 
 `;
 
 exports[`createStyled() only renders styles once, even when component rerenders 2`] = `".a {text-decoration: none;}"`;
+
+exports[`createStyled() supports styled component composition 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef type=\\"button\\">
+          <button className=\\"a b c\\" type=\\"button\\">
+            Normal
+          </button>
+        </ForwardRef>
+        <ForwardRef type=\\"submit\\">
+          <ForwardRef className=\\"d e\\" type=\\"submit\\">
+            <button className=\\"a b c d e\\" type=\\"submit\\">
+              Block
+            </button>
+          </ForwardRef>
+        </ForwardRef>
+        <ForwardRef disabled>
+          <ForwardRef disabled className=\\"f g\\">
+            <ForwardRef disabled className=\\"d e f g\\">
+              <button disabled className=\\"a b c d e f g\\">
+                Large
+              </button>
+            </ForwardRef>
+          </ForwardRef>
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() supports styled component composition 2`] = `".a {display: inline-flex;}.b {text-align: center;}.c {padding: 1rem;}.d {display: flex;}.e {width: 100%;}.f {padding: 2rem;}.g {font-size: 18px;}"`;
 
 exports[`createStyled() supports variants 1`] = `
 "<Wrapper>

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createStyled() creates and renders a button with defined styles 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef>
+          <button className=\\"a b c\\">
+            Test
+          </button>
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() creates and renders a button with defined styles 2`] = `".a {display: inline-flex;}.b {text-align: center;}.c {padding: 1rem;}"`;

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`createStyled() can use and define CSS variables 1`] = `
     <div dir=\\"ltr\\">
       <ThemeProvider name=\\"twilight\\">
         <ForwardRef>
-          <code className=\\"a b\\" />
+          <code className=\\"a b c\\" />
         </ForwardRef>
       </ThemeProvider>
     </div>
@@ -58,7 +58,7 @@ exports[`createStyled() can use and define CSS variables 1`] = `
 </Wrapper>"
 `;
 
-exports[`createStyled() can use and define CSS variables 2`] = `".a {font-size: var(--text-sm-size);}.b {line-height: 1.25;}"`;
+exports[`createStyled() can use and define CSS variables 2`] = `".a {font-size: var(--text-sm-size);}.b {line-height: 1.25;}.c {--element-level-var: nice;}"`;
 
 exports[`createStyled() creates and renders a button with defined styles 1`] = `
 "<Wrapper>

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -17,3 +17,21 @@ exports[`createStyled() creates and renders a button with defined styles 1`] = `
 `;
 
 exports[`createStyled() creates and renders a button with defined styles 2`] = `".a {display: inline-flex;}.b {text-align: center;}.c {padding: 1rem;}"`;
+
+exports[`createStyled() only renders styles once, even when component rerenders 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef href=\\"/foo/bar\\">
+          <a className=\\"a\\" href=\\"/foo/bar\\">
+            Test
+          </a>
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() only renders styles once, even when component rerenders 2`] = `".a {text-decoration: none;}"`;

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`createStyled() can pass custom props/attributes 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef
+          className=\\"will-be-appended\\"
+          placeholder=\\"Search...\\"
+          type=\\"text\\"
+        >
+          <input
+            className=\\"a b c will-be-appended\\"
+            placeholder=\\"Search...\\"
+            type=\\"text\\"
+          />
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() can pass custom props/attributes 2`] = `".a {border: 1px solid black;}.b {padding: 1rem;}.c:focus {outline: none;}"`;
+
+exports[`createStyled() can use and define CSS variables 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef>
+          <code className=\\"a b\\" />
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() can use and define CSS variables 2`] = `".a {font-size: var(--text-sm-size);}.b {line-height: 1.25;}"`;
+
 exports[`createStyled() creates and renders a button with defined styles 1`] = `
 "<Wrapper>
   <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -75,3 +75,62 @@ exports[`createStyled() only renders styles once, even when component rerenders 
 `;
 
 exports[`createStyled() only renders styles once, even when component rerenders 2`] = `".a {text-decoration: none;}"`;
+
+exports[`createStyled() supports variants 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef palette=\\"success\\">
+          <div className=\\"a b\\" palette=\\"success\\">
+            <div>
+              <h1>Title</h1>
+              And other content!
+            </div>
+          </div>
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() supports variants 2`] = `".a {background: var(--palette-neutral-bg-base);}.b {background: var(--palette-success-bg-base);}.c {background: var(--palette-failure-bg-base);}.d {background: var(--palette-warning-bg-base);}"`;
+
+exports[`createStyled() supports variants 3`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef palette=\\"failure\\">
+          <div className=\\"a c\\" palette=\\"failure\\">
+            <div>
+              <h1>Title</h1>
+              And other content!
+            </div>
+          </div>
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
+exports[`createStyled() supports variants 4`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef>
+          <div className=\\"a\\">
+            <div>
+              <h1>Title</h1>
+              And other content!
+            </div>
+          </div>
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`createStyled() can access the ref 1`] = `
+"<Wrapper>
+  <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
+    <div dir=\\"ltr\\">
+      <ThemeProvider name=\\"twilight\\">
+        <ForwardRef>
+          <svg ref={mockConstructor()} className=\\"a b c\\" />
+        </ForwardRef>
+      </ThemeProvider>
+    </div>
+  </DirectionProvider>
+</Wrapper>"
+`;
+
 exports[`createStyled() can pass custom props/attributes 1`] = `
 "<Wrapper>
   <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>

--- a/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/createStyled.test.tsx.snap
@@ -73,10 +73,10 @@ exports[`createStyled() creates and renders a button with defined styles 1`] = `
 exports[`createStyled() creates and renders a button with defined styles 2`] = `".a {display: inline-flex;}.b {text-align: center;}.c {padding: 1rem;}"`;
 
 exports[`createStyled() only renders styles once, even when component rerenders 1`] = `
-"<Wrapper>
+"<Wrapper theme=\\"day\\">
   <DirectionProvider direction=\\"ltr\\" wrapper={<div />}>
     <div dir=\\"ltr\\">
-      <ThemeProvider name=\\"twilight\\">
+      <ThemeProvider name=\\"day\\">
         <ForwardRef href=\\"/foo/bar\\">
           <a className=\\"a\\" href=\\"/foo/bar\\">
             Test

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { render } from 'rut-dom';
-import { getRenderedStyles } from '@aesthetic/core/lib/testing';
+import { getRenderedStyles, purgeStyles } from '@aesthetic/core/lib/testing';
 import { createStyled } from '../src';
 import { Wrapper } from './__mocks__/Button';
 import { setupAestheticReact, teardownAestheticReact } from './helpers';
@@ -13,6 +13,7 @@ describe('createStyled()', () => {
   });
 
   afterEach(() => {
+    purgeStyles();
     teardownAestheticReact();
   });
 
@@ -27,6 +28,26 @@ describe('createStyled()', () => {
       wrapper: <Wrapper />,
     });
 
+    expect(debug({ log: false })).toMatchSnapshot();
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+  });
+
+  it('only renders styles once, even when component rerenders', () => {
+    const spy = jest.fn(() => ({
+      textDecoration: 'none',
+    }));
+
+    const Link = createStyled('a', spy);
+
+    const { debug, update } = render<{}>(<Link href="/foo/bar">Test</Link>, {
+      wrapper: <Wrapper />,
+    });
+
+    update();
+    update();
+    update();
+
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(debug({ log: false })).toMatchSnapshot();
     expect(getRenderedStyles('standard')).toMatchSnapshot();
   });

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -134,9 +134,21 @@ describe('createStyled()', () => {
     expect(debug({ log: false })).toMatchSnapshot();
   });
 
-  // const Icon = createStyled('svg', {
-  //   display: 'inline-block',
-  //   verticalAlign: 'bottom',
-  //   width: '16px',
-  // });
+  it('can access the ref', () => {
+    const Icon = createStyled('svg', () => ({
+      display: 'inline-block',
+      verticalAlign: 'bottom',
+      width: '16px',
+    }));
+
+    const svg = document.createElement('svg');
+    const spy = jest.fn();
+    const { debug } = render<{}>(<Icon ref={spy} />, {
+      mockRef: () => svg,
+      wrapper: <Wrapper />,
+    });
+
+    expect(spy).toHaveBeenCalledWith(svg);
+    expect(debug({ log: false })).toMatchSnapshot();
+  });
 });

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -134,16 +134,47 @@ describe('createStyled()', () => {
     expect(debug({ log: false })).toMatchSnapshot();
   });
 
-  it('can access the ref', () => {
-    const Icon = createStyled('svg', {
-      display: 'inline-block',
-      verticalAlign: 'bottom',
-      width: '16px',
+  it('supports styled component composition', () => {
+    const Button = createStyled('button', () => ({
+      display: 'inline-flex',
+      textAlign: 'center',
+      padding: '1rem',
+    }));
+
+    const BlockButton = createStyled(Button, {
+      display: 'flex',
+      width: '100%',
     });
 
-    const svg = document.createElement('svg');
+    const LargeBlockButton = createStyled(BlockButton, {
+      padding: '2rem',
+      fontSize: 18,
+    });
+
+    const { debug } = render<{}>(
+      <>
+        <Button type="button">Normal</Button>
+        <BlockButton type="submit">Block</BlockButton>
+        <LargeBlockButton disabled>Large</LargeBlockButton>
+      </>,
+      {
+        wrapper: <Wrapper />,
+      },
+    );
+
+    expect(debug({ log: false })).toMatchSnapshot();
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+  });
+
+  it('can access the ref from multiple layers of composition', () => {
+    const Leaf = createStyled('main', {});
+    const Branch = createStyled(Leaf, {});
+    const Trunk = createStyled(Branch, {});
+    const Root = createStyled(Trunk, {});
+
+    const svg = document.createElement('main');
     const spy = jest.fn();
-    const { debug } = render<{}>(<Icon ref={spy} />, {
+    const { debug } = render<{}>(<Root ref={spy} />, {
       mockRef: () => svg,
       wrapper: <Wrapper />,
     });

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { render } from 'rut-dom';
+import { StyleSheet } from '@aesthetic/core';
 import { getRenderedStyles, purgeStyles } from '@aesthetic/core/lib/testing';
 import { createStyled } from '../src';
 import { Wrapper } from './__mocks__/Button';
@@ -15,6 +16,48 @@ describe('createStyled()', () => {
   afterEach(() => {
     purgeStyles();
     teardownAestheticReact();
+  });
+
+  it('errors for a non-react element type', () => {
+    expect(() =>
+      createStyled(
+        // @ts-expect-error
+        123,
+        {},
+      ),
+    ).toThrow('Styled components must extend an HTML element or React component, found number.');
+  });
+
+  it('errors for invalid style sheet factory', () => {
+    expect(() =>
+      createStyled(
+        'div',
+        // @ts-expect-error
+        true,
+      ),
+    ).toThrow('Styled components require a style sheet factory function, found boolean.');
+  });
+
+  it('errors when a non-styled react component is passed', () => {
+    function Foo() {
+      return <div />;
+    }
+
+    expect(() => createStyled(Foo, {})).toThrow(
+      'Styled components may only extend other styled components.',
+    );
+  });
+
+  it('sets static properties on component', () => {
+    const Button = createStyled('button', {});
+
+    expect(Button.displayName).toBe('styled(button)');
+    expect(Button.styleSheet).toBeInstanceOf(StyleSheet);
+
+    const ComposedButton = createStyled(Button, {});
+
+    expect(ComposedButton.displayName).toBe('styled(styled(button))');
+    expect(ComposedButton.styleSheet).toBeInstanceOf(StyleSheet);
   });
 
   it('creates and renders a button with defined styles', () => {

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -53,13 +53,13 @@ describe('createStyled()', () => {
   });
 
   it('can pass custom props/attributes', () => {
-    const Input = createStyled('input', () => ({
+    const Input = createStyled('input', {
       border: '1px solid black',
       padding: '1rem',
       ':focus': {
         outline: 'none',
       },
-    }));
+    });
 
     const { debug } = render<{}>(
       <Input disabled={false} type="text" placeholder="Search..." className="will-be-appended" />,
@@ -135,11 +135,11 @@ describe('createStyled()', () => {
   });
 
   it('can access the ref', () => {
-    const Icon = createStyled('svg', () => ({
+    const Icon = createStyled('svg', {
       display: 'inline-block',
       verticalAlign: 'bottom',
       width: '16px',
-    }));
+    });
 
     const svg = document.createElement('svg');
     const spy = jest.fn();

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -51,4 +51,41 @@ describe('createStyled()', () => {
     expect(debug({ log: false })).toMatchSnapshot();
     expect(getRenderedStyles('standard')).toMatchSnapshot();
   });
+
+  it('can pass custom props/attributes', () => {
+    const Input = createStyled('input', () => ({
+      border: '1px solid black',
+      padding: '1rem',
+      ':focus': {
+        outline: 'none',
+      },
+    }));
+
+    const { debug } = render<{}>(
+      <Input disabled={false} type="text" placeholder="Search..." className="will-be-appended" />,
+      {
+        wrapper: <Wrapper />,
+      },
+    );
+
+    expect(debug({ log: false })).toMatchSnapshot();
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+  });
+
+  it('can use and define CSS variables', () => {
+    const Code = createStyled('code', (css) => ({
+      fontSize: css.var('text-sm-size'),
+      lineHeight: css.token('text-sm-line-height') as number,
+      '@variables': {
+        elementLevelVar: 'nice',
+      },
+    }));
+
+    const { debug } = render<{}>(<Code />, {
+      wrapper: <Wrapper />,
+    });
+
+    expect(debug({ log: false })).toMatchSnapshot();
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+  });
 });

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -40,7 +40,7 @@ describe('createStyled()', () => {
     const Link = createStyled('a', spy);
 
     const { debug, update } = render<{}>(<Link href="/foo/bar">Test</Link>, {
-      wrapper: <Wrapper />,
+      wrapper: <Wrapper theme="day" />,
     });
 
     update();

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -88,4 +88,55 @@ describe('createStyled()', () => {
     expect(debug({ log: false })).toMatchSnapshot();
     expect(getRenderedStyles('standard')).toMatchSnapshot();
   });
+
+  it('supports variants', () => {
+    interface AlertProps {
+      palette?: 'success' | 'failure' | 'warning';
+    }
+
+    const Alert = createStyled<'div', AlertProps>('div', (css) => ({
+      background: css.var('palette-neutral-bg-base'),
+      '@variants': {
+        palette: {
+          success: {
+            background: css.var('palette-success-bg-base'),
+          },
+          failure: {
+            background: css.var('palette-failure-bg-base'),
+          },
+          warning: {
+            background: css.var('palette-warning-bg-base'),
+          },
+        },
+      },
+    }));
+
+    const { debug, update } = render<AlertProps>(
+      <Alert palette="success">
+        <div>
+          <h1>Title</h1>And other content!
+        </div>
+      </Alert>,
+      {
+        wrapper: <Wrapper />,
+      },
+    );
+
+    expect(debug({ log: false })).toMatchSnapshot();
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+
+    update({ palette: 'failure' });
+
+    expect(debug({ log: false })).toMatchSnapshot();
+
+    update({ palette: undefined });
+
+    expect(debug({ log: false })).toMatchSnapshot();
+  });
+
+  // const Icon = createStyled('svg', {
+  //   display: 'inline-block',
+  //   verticalAlign: 'bottom',
+  //   width: '16px',
+  // });
 });

--- a/packages/react/tests/createStyled.test.tsx
+++ b/packages/react/tests/createStyled.test.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable react/jsx-no-literals */
+
+import React from 'react';
+import { render } from 'rut-dom';
+import { getRenderedStyles } from '@aesthetic/core/lib/testing';
+import { createStyled } from '../src';
+import { Wrapper } from './__mocks__/Button';
+import { setupAestheticReact, teardownAestheticReact } from './helpers';
+
+describe('createStyled()', () => {
+  beforeEach(() => {
+    setupAestheticReact();
+  });
+
+  afterEach(() => {
+    teardownAestheticReact();
+  });
+
+  it('creates and renders a button with defined styles', () => {
+    const Button = createStyled('button', () => ({
+      display: 'inline-flex',
+      textAlign: 'center',
+      padding: '1rem',
+    }));
+
+    const { debug } = render<{}>(<Button>Test</Button>, {
+      wrapper: <Wrapper />,
+    });
+
+    expect(debug({ log: false })).toMatchSnapshot();
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+  });
+});

--- a/packages/react/tests/useTheme.test.tsx
+++ b/packages/react/tests/useTheme.test.tsx
@@ -31,9 +31,6 @@ describe('useTheme()', () => {
   });
 
   it('returns a preferred theme if no name provided', () => {
-    // @ts-expect-error Only need to mock matches
-    window.matchMedia = () => ({ matches: false });
-
     let theme;
 
     function Component() {

--- a/packages/react/tests/withTheme.test.tsx
+++ b/packages/react/tests/withTheme.test.tsx
@@ -86,9 +86,6 @@ describe('withTheme()', () => {
   });
 
   it('returns new theme if theme context changes', () => {
-    // @ts-expect-error Only need to mock matches
-    window.matchMedia = () => ({ matches: false });
-
     const Wrapped = withTheme()(BaseComponent);
     const { root, update } = render<ThemeProviderProps>(
       <ThemeProvider name="dawn">

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,11 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,48 +2,48 @@
 # yarn lockfile v1
 
 
-"@aesthetic/addon-mixins@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@aesthetic/addon-mixins/-/addon-mixins-0.1.3.tgz#5ee1c844f9e31b7af37d44a9f5934784e5b6e9b6"
-  integrity sha512-m5LpNMupJJ4Z6xPufyr3QwaAQ35C8rD9XcWupeOrha8EmzkReAkAeLL1NQVdoXq6hHPm82EM5a1DYMozVEz9BA==
+"@aesthetic/addon-mixins@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@aesthetic/addon-mixins/-/addon-mixins-0.1.4.tgz#e8959a951e3dcadf04c6796fee4c4662f146eb76"
+  integrity sha512-YJf7SBet4a9WSgu+7KeqeQ8qEGcjlZESTgJW5rp4MU2NzyCbUSl8QyHaW4S/49X0N4VRdP7WLNe/Kr3ihobXzw==
   dependencies:
-    "@aesthetic/utils" "^0.4.2"
+    "@aesthetic/utils" "^0.4.3"
 
-"@aesthetic/core@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@aesthetic/core/-/core-0.4.5.tgz#2ece4ef07649ff078cf6566ea2584fe00ece144c"
-  integrity sha512-VYf4kOk8Fy6U/vYZTIaEISdnYmpQvu3URTsyVnsO692JQYsPBSY7hBQ5bzKkY902QF0GD5SpxXq5rItPKECJgw==
+"@aesthetic/core@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@aesthetic/core/-/core-0.4.6.tgz#ba02c81ce729cca877c73ff128eeefd537b60db7"
+  integrity sha512-GF77cBIZknfyDB2eDDo9kzZq9DTq0YjcjqWu1hJrKgo3jS/0KeXsGKAi8soqh4nOqXEUlcI197VjSjWB2Pyjng==
   dependencies:
-    "@aesthetic/sss" "^0.4.3"
-    "@aesthetic/style" "^0.4.2"
-    "@aesthetic/system" "^0.4.4"
+    "@aesthetic/sss" "^0.4.4"
+    "@aesthetic/style" "^0.4.3"
+    "@aesthetic/system" "^0.4.5"
     "@aesthetic/types" "^0.2.1"
-    "@aesthetic/utils" "^0.4.2"
+    "@aesthetic/utils" "^0.4.3"
 
-"@aesthetic/sss@^0.4.3":
+"@aesthetic/sss@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@aesthetic/sss/-/sss-0.4.4.tgz#6e829f8f1f8c2086dace69809cfe472605d5df2e"
+  integrity sha512-sfBPCEB3YlzNDzVjZi6WGe2a8+whrLpNWr85Z/VYCJjMjGfac0m2SYnv+RlcfP01Xs18zurTxa8fdJD0iJW6QQ==
+  dependencies:
+    "@aesthetic/types" "^0.2.1"
+    "@aesthetic/utils" "^0.4.3"
+
+"@aesthetic/style@^0.4.3":
   version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@aesthetic/sss/-/sss-0.4.3.tgz#7eae565d567f289595442534c754a6e6affcfb70"
-  integrity sha512-ju2+XMbsw/W3D9MIhaUQalFyGBKEsi2oy5bOLIE5seECjnSVu+LuZgYZLABvbN0FRIeZ/Zlf6soUqL6QPIuJPQ==
+  resolved "https://registry.yarnpkg.com/@aesthetic/style/-/style-0.4.3.tgz#937c9ea8a20aaa5c2998abcb7327e73b6a981906"
+  integrity sha512-CH5Ict2fZ5ne5mJxj+21k6Sb4tw1aZ6i7v0k+Kdgpzc8QzWAUE38ZYM6Ip3Za3a0uxqcFcVQ2SzcSk1AXIHuaA==
   dependencies:
     "@aesthetic/types" "^0.2.1"
-    "@aesthetic/utils" "^0.4.2"
-
-"@aesthetic/style@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@aesthetic/style/-/style-0.4.2.tgz#10ed4577f02dd117c7c295b8bf4d3627f595c27b"
-  integrity sha512-VkG2VQo1Ga3KPhw6S29k7s4jhC/NtLB4bttkT+rLfz2Ry/ecitXfKBrZ+DvWTCdVKAaxh/YWME+XcV43T6ttug==
-  dependencies:
-    "@aesthetic/types" "^0.2.1"
-    "@aesthetic/utils" "^0.4.2"
+    "@aesthetic/utils" "^0.4.3"
     sort-css-media-queries "^1.5.0"
 
-"@aesthetic/system@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@aesthetic/system/-/system-0.4.4.tgz#7b3905c20e2a6a0372347c4033af5cd726b236e6"
-  integrity sha512-7i8hZmzHc+CcL9xLW9zTeDh96Lg9Fl9KewWmOwrUvcLuMxj6jcbZI1y6JdFymgcopJXjvdMaM5jkIGE8sgkCgg==
+"@aesthetic/system@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@aesthetic/system/-/system-0.4.5.tgz#b063c8bb24a66253d0c9a61876fb9c999550388d"
+  integrity sha512-OvVoN3CwBnlwX1AJ4l+MyUMP7OOMMrNEfqCijhqU8Rn2pttUQ/NFBfp9Qy9twkAUU6zqZ1vlPY9mex/rWMZl6Q==
   dependencies:
     "@aesthetic/types" "^0.2.1"
-    "@aesthetic/utils" "^0.4.2"
+    "@aesthetic/utils" "^0.4.3"
 
 "@aesthetic/types@^0.2.1":
   version "0.2.1"
@@ -52,10 +52,10 @@
   dependencies:
     csstype "^3.0.3"
 
-"@aesthetic/utils@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@aesthetic/utils/-/utils-0.4.2.tgz#d658cee4260045dfdeb69608d7f9d636f7f967b0"
-  integrity sha512-hwZYk0ObntMKNt+NpvOv142NAwoBZgYP9x2na9DWvQA941GGHCUKdWi4f19vciG49FsruvoI0cG0bWvUqh3oRA==
+"@aesthetic/utils@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@aesthetic/utils/-/utils-0.4.3.tgz#5a1d3ec43e979084c64006710ccd6a80cd86a4e5"
+  integrity sha512-pORQ523bOKLinzxI5akxmwY+erMxCQJnJ8aXdo5KwnsWRe62aiIPUAi1haPq5Fhyx/CEQPmpzD+XhfSfAopfqg==
   dependencies:
     string-hash "^1.1.3"
 
@@ -8695,10 +8695,10 @@ rollup-plugin-node-externals@^2.2.0:
   dependencies:
     find-up "^4.1.0"
 
-rollup@^2.28.1:
-  version "2.28.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.28.1.tgz#ceedca3cdb013c2fa8f22f958a29c203368159ea"
-  integrity sha512-DOtVoqOZt3+FjPJWLU8hDIvBjUylc9s6IZvy76XklxzcLvAQLtVAG/bbhsMhcWnYxC0TKKcf1QQ/tg29zeID0Q==
+rollup@^2.28.2:
+  version "2.28.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.28.2.tgz#599ec4978144a82d8a8ec3d37670a8440cb04e4b"
+  integrity sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==
   optionalDependencies:
     fsevents "~2.1.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,14 +9,14 @@
   dependencies:
     "@aesthetic/utils" "^0.4.2"
 
-"@aesthetic/core@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@aesthetic/core/-/core-0.4.4.tgz#3cc76f7880900aa4348e86085b70cc9d1ea0226f"
-  integrity sha512-leT60BlH+F3eRw81ozYlgs8NZo+YM/geRodsdkaJJdtIgyxNG8ERQQZ0y3s1NOdCOGntfCc3mI5hdRYljfFoTA==
+"@aesthetic/core@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@aesthetic/core/-/core-0.4.5.tgz#2ece4ef07649ff078cf6566ea2584fe00ece144c"
+  integrity sha512-VYf4kOk8Fy6U/vYZTIaEISdnYmpQvu3URTsyVnsO692JQYsPBSY7hBQ5bzKkY902QF0GD5SpxXq5rItPKECJgw==
   dependencies:
     "@aesthetic/sss" "^0.4.3"
     "@aesthetic/style" "^0.4.2"
-    "@aesthetic/system" "^0.4.3"
+    "@aesthetic/system" "^0.4.4"
     "@aesthetic/types" "^0.2.1"
     "@aesthetic/utils" "^0.4.2"
 
@@ -37,10 +37,10 @@
     "@aesthetic/utils" "^0.4.2"
     sort-css-media-queries "^1.5.0"
 
-"@aesthetic/system@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@aesthetic/system/-/system-0.4.3.tgz#ce5890f16583272acfa18626c7569989c6179bd1"
-  integrity sha512-awtBrwmHa5beXavNENaE6OqQV0sm1a+zetzMX9V6JMIThZqwcOkTGN8XQ6oa3JuXpJt6d05JZTXqdV0sxH2EcQ==
+"@aesthetic/system@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@aesthetic/system/-/system-0.4.4.tgz#7b3905c20e2a6a0372347c4033af5cd726b236e6"
+  integrity sha512-7i8hZmzHc+CcL9xLW9zTeDh96Lg9Fl9KewWmOwrUvcLuMxj6jcbZI1y6JdFymgcopJXjvdMaM5jkIGE8sgkCgg==
   dependencies:
     "@aesthetic/types" "^0.2.1"
     "@aesthetic/utils" "^0.4.2"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/react/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

Most competitors support this type of pattern, and I'm not entirely against it for small, dumb, presentational components. 

With this approach, we also have full control of the render cycle and can cache if necessary.

- [x] Add HTML element API.
- [x] Add component extension/composition API.

## Example

```ts
const Button = createStyled('button', (css) => ({
  display: 'inline-flex',
  textAlign: 'center',
  padding: css.var('spacing-md'),
}));

const BlockButton = createStyled(Button, {
  display: 'flex',
  width: '100%',
});

const LargeBlockButton = createStyled(BlockButton, (css) => ({
  padding: css.var('spacing-lg'),
  fontSize: 18,
}));
```

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [x] Documentation has been updated for my changes.
