### PR TITLE
new: Add `useCss` hook.

### DIFF
--- a/packages/react/src/styles.tsx
+++ b/packages/react/src/styles.tsx
@@ -14,7 +14,10 @@ export const { useStyles, withStyles } = createStyleHelpers(aesthetic, {
   useTheme,
 });
 
-export function useCss(rule: Rule, options?: RenderOptions): ClassName {
+export function useCss(
+  rule: Rule,
+  options?: Omit<RenderOptions, 'className' | 'rankings' | 'type'>,
+): ClassName {
   return useMemo(() => aesthetic.getEngine().renderRule(rule, options), [rule, options]);
 }
 

--- a/packages/react/src/styles.tsx
+++ b/packages/react/src/styles.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { LocalBlock, Utilities, LocalSheet } from '@aesthetic/core';
 import { createStyleHelpers } from '@aesthetic/core-react';
 import { objectLoop } from '@aesthetic/utils';
-import { ClassName } from '@aesthetic/types';
+import { ClassName, RenderOptions, Rule } from '@aesthetic/types';
 import aesthetic from './aesthetic';
 import { useDirection } from './direction';
 import { useTheme } from './theme';
@@ -13,6 +13,10 @@ export const { useStyles, withStyles } = createStyleHelpers(aesthetic, {
   useDirection,
   useTheme,
 });
+
+export function useCss(rule: Rule, options?: RenderOptions): ClassName {
+  return useMemo(() => aesthetic.getEngine().renderRule(rule, options), [rule, options]);
+}
 
 function getVariantsFromProps(
   styleSheet: LocalSheet<unknown, LocalBlock, ClassName>,

--- a/packages/react/tests/__snapshots__/useCss.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/useCss.test.tsx.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`useCss() renders a button and its base styles 1`] = `".a {position: relative;}.b {display: inline-flex;}.c {text-align: center;}.d {padding: 8px;}"`;
+
+exports[`useCss() renders with custom options 1`] = `"@supports (display: inline-flex) {.c7a2jwm {position: relative;}}@supports (display: inline-flex) {.cz4mqki {display: inline-flex;}}@supports (display: inline-flex) {.c9n9uql {text-align: center;}}@supports (display: inline-flex) {.ch6ahvm {padding: 8px;}}"`;

--- a/packages/react/tests/__snapshots__/useCss.test.tsx.snap
+++ b/packages/react/tests/__snapshots__/useCss.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useCss() renders a button and its base styles 1`] = `".a {position: relative;}.b {display: inline-flex;}.c {text-align: center;}.d {padding: 8px;}"`;

--- a/packages/react/tests/useCss.test.tsx
+++ b/packages/react/tests/useCss.test.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable react/jsx-no-literals */
+
+import React from 'react';
+import { render } from 'rut-dom';
+import { getRenderedStyles } from '@aesthetic/style/test';
+import { Rule } from '@aesthetic/types';
+import { useCss } from '../src';
+import { createStyleSheet, ButtonProps, Wrapper } from './__mocks__/Button';
+import { dawnTheme, setupAestheticReact, teardownAestheticReact, twilightTheme } from './helpers';
+
+describe('useCss()', () => {
+  const styles: Rule = {
+    position: 'relative',
+    display: 'inline-flex',
+    textAlign: 'center',
+    padding: 8,
+  };
+
+  function Button({ children }: ButtonProps) {
+    const className = useCss(styles);
+
+    return (
+      <button type="button" className={className}>
+        {children}
+      </button>
+    );
+  }
+
+  beforeEach(() => {
+    setupAestheticReact();
+  });
+
+  afterEach(() => {
+    teardownAestheticReact();
+  });
+
+  it('renders a button and its base styles', () => {
+    const { root } = render<ButtonProps>(<Button>Child</Button>, {
+      wrapper: <Wrapper />,
+    });
+
+    expect(getRenderedStyles('standard')).toMatchSnapshot();
+
+    expect(root.findOne('button')).toHaveProp('className', 'a b c d');
+  });
+});

--- a/packages/react/tests/useCss.test.tsx
+++ b/packages/react/tests/useCss.test.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/jsx-no-literals */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { render } from 'rut-dom';
 import { getRenderedStyles } from '@aesthetic/style/test';
 import { Rule } from '@aesthetic/types';
 import { useCss } from '../src';
-import { createStyleSheet, ButtonProps, Wrapper } from './__mocks__/Button';
-import { dawnTheme, setupAestheticReact, teardownAestheticReact, twilightTheme } from './helpers';
+import aesthetic from '../src/aesthetic';
+import { ButtonProps } from './__mocks__/Button';
+import { setupAestheticReact, teardownAestheticReact } from './helpers';
 
 describe('useCss()', () => {
   const styles: Rule = {
@@ -26,6 +27,23 @@ describe('useCss()', () => {
     );
   }
 
+  function ButtonWithOptions({ children }: ButtonProps) {
+    const options = useMemo(
+      () => ({
+        deterministic: true,
+        conditions: ['@supports (display: inline-flex)'],
+      }),
+      [],
+    );
+    const className = useCss(styles, options);
+
+    return (
+      <button type="button" className={className}>
+        {children}
+      </button>
+    );
+  }
+
   beforeEach(() => {
     setupAestheticReact();
   });
@@ -35,12 +53,32 @@ describe('useCss()', () => {
   });
 
   it('renders a button and its base styles', () => {
-    const { root } = render<ButtonProps>(<Button>Child</Button>, {
-      wrapper: <Wrapper />,
-    });
+    const { root } = render<ButtonProps>(<Button>Child</Button>);
 
     expect(getRenderedStyles('standard')).toMatchSnapshot();
 
     expect(root.findOne('button')).toHaveProp('className', 'a b c d');
+  });
+
+  it('renders with custom options', () => {
+    const { root } = render<ButtonProps>(<ButtonWithOptions>Child</ButtonWithOptions>);
+
+    expect(getRenderedStyles('conditions')).toMatchSnapshot();
+
+    expect(root.findOne('button')).toHaveProp('className', 'c7a2jwm cz4mqki c9n9uql ch6ahvm');
+  });
+
+  it('only renders styles once', () => {
+    const spy = jest.spyOn(aesthetic.getEngine(), 'renderRule');
+
+    const { update } = render<ButtonProps>(<Button>Child</Button>);
+
+    update();
+    update();
+    update();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/react/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

Provides a very simple hook for rendering raw low-level CSS.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [ ] Documentation has been updated for my changes.
